### PR TITLE
Make library work across core and photon

### DIFF
--- a/firmware/Adafruit_ILI9341.cpp
+++ b/firmware/Adafruit_ILI9341.cpp
@@ -19,6 +19,8 @@ MIT license, all text above must be included in any redistribution
 
 #include "application.h"
 
+STM32_Pin_Info* PIN_MAP = HAL_Pin_Map(); // Pointer required for highest access speed
+
 // Constructor when using hardware SPI.  Faster, but must use specific SPI pins (http://docs.spark.io/#/hardware):
 // A2 : SS(Slave Select)
 // A3 : SCK(Serial Clock)

--- a/firmware/Adafruit_ILI9341.h
+++ b/firmware/Adafruit_ILI9341.h
@@ -24,8 +24,19 @@ MIT license, all text above must be included in any redistribution
 #define pgm_read_byte(addr) (*(const unsigned char *)(addr))
 #define pgm_read_word(addr) (*(const unsigned short *)(addr))
 
-#define pinLO(_pin)	(PIN_MAP[_pin].gpio_peripheral->BRR = PIN_MAP[_pin].gpio_pin)
-#define pinHI(_pin)	(PIN_MAP[_pin].gpio_peripheral->BSRR = PIN_MAP[_pin].gpio_pin)
+#if defined(PLATFORM_ID)  //Only defined if a Particle device
+  #include "application.h"
+#if (PLATFORM_ID == 0)  // Core
+  #define pinLO(_pin) (PIN_MAP[_pin].gpio_peripheral->BRR = PIN_MAP[_pin].gpio_pin)
+  #define pinHI(_pin) (PIN_MAP[_pin].gpio_peripheral->BSRR = PIN_MAP[_pin].gpio_pin)
+#elif (PLATFORM_ID == 6) // Photon
+  #define pinLO(_pin) (PIN_MAP[_pin].gpio_peripheral->BSRRH = PIN_MAP[_pin].gpio_pin)
+  #define pinHI(_pin) (PIN_MAP[_pin].gpio_peripheral->BSRRL = PIN_MAP[_pin].gpio_pin)
+#else
+  #error "*** PLATFORM_ID not supported by this library. PLATFORM should be Core or Photon ***"
+#endif
+#endif
+
 #define inline inline __attribute__((always_inline))
 
 //typedef unsigned char prog_uchar;


### PR DESCRIPTION
modify macros to work on spark core and particle photon
https://community.particle.io/t/photon-and-the-pin-map-challenge/12223

and move PIN_MAP definition to cpp file
https://community.particle.io/t/photon-and-the-pin-map-challenge/12223/20
