### PR TITLE
replaced references to BRR and BSRR as mentioned in https://community…

### DIFF
--- a/firmware/Adafruit_ILI9341.h
+++ b/firmware/Adafruit_ILI9341.h
@@ -24,8 +24,8 @@ MIT license, all text above must be included in any redistribution
 #define pgm_read_byte(addr) (*(const unsigned char *)(addr))
 #define pgm_read_word(addr) (*(const unsigned short *)(addr))
 
-#define pinLO(_pin)	(PIN_MAP[_pin].gpio_peripheral->BRR = PIN_MAP[_pin].gpio_pin)
-#define pinHI(_pin)	(PIN_MAP[_pin].gpio_peripheral->BSRR = PIN_MAP[_pin].gpio_pin)
+#define pinLO(_pin)	(pinResetFast(_pin))
+#define pinHI(_pin)	(pinSetFast(_pin))
 #define inline inline __attribute__((always_inline))
 
 //typedef unsigned char prog_uchar;


### PR DESCRIPTION
….particle.io/t/pin-map-issue-with-adafruit-ssd1351-oled-sd-card/16110/5 as it does not verify in the particle build IDE

I was trying to use your library in the Particle Build IDE and got some compile errors regarding the GPIO pins. After a bit of digging I found this community post detailing the change that needed to be made in order to compile again with the latest code.

http://community.particle.io/t/pin-map-issue-with-adafruit-ssd1351-oled-sd-card/16110/2

I can confirm that the example program now works fine on my Photon compiled through the cloud IDE.

Should resolve issue #3 
